### PR TITLE
Remove helm hook for dev spaces

### DIFF
--- a/charts/devspaces/templates/operator.yaml
+++ b/charts/devspaces/templates/operator.yaml
@@ -3,9 +3,6 @@ kind: Subscription
 metadata:
   name: devspaces
   namespace: openshift-operators
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-1"
 spec:
   channel: stable
   installPlanApproval: Automatic


### PR DESCRIPTION
This hook was causing an issue with the installation of the DevSpaces Operator.  It was added in tandem with the `argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true` annotation, and it turns out that is the real key to having the entire app sync properly. 